### PR TITLE
Support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/contracts": "^5.8|^6.0|^6.2",
-        "illuminate/support": "^5.8|^6.0|^6.2",
+        "illuminate/contracts": "^5.8|^6.0|^7.0",
+        "illuminate/support": "^5.8|^6.0|^7.0",
         "graham-campbell/manager": "^4.0",
         "vimeo/vimeo-api": "^3.0.2"
     },
     "require-dev": {
-        "laravel/framework": "^5.8|^6.0|^6.2",
+        "laravel/framework": "^5.8|^6.0|^7.0",
         "graham-campbell/analyzer": "^2.0",
         "graham-campbell/testbench": "^5.2",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
This adds support for Laravel 7, while maintaining support for previous versions.

It overwrites the `^6.2` constraint as it was redundant given the `^6.0` constraint.