### PR TITLE
Laravel 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/contracts": "^5.8|^6.0|^7.0",
-        "illuminate/support": "^5.8|^6.0|^7.0",
+        "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
         "graham-campbell/manager": "^4.0",
         "vimeo/vimeo-api": "^3.0.3"
     },
     "require-dev": {
-        "laravel/framework": "^5.8|^6.0|^7.0",
+        "laravel/framework": "^5.8|^6.0|^7.0|^8.0",
         "graham-campbell/analyzer": "^2.0",
         "graham-campbell/testbench": "^5.2",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Updated the composer dependency versions to include Laravel 8 and Illuminate 8 packages. 

There are no code changes, and tests continue to pass as no significant changes have affected this package's behavior. 