### PR TITLE
Update illuminate and laravel framework versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
-        "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "graham-campbell/manager": "^5.0",
         "vimeo/vimeo-api": "^3.0"
     },
     "require-dev": {
-        "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "graham-campbell/analyzer": "^2.0|^3.1|^4.1|^5.0",
         "graham-campbell/testbench": "^5.2|^6.1",
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
Bump dependencies for Laravel 13

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency constraint update only; primary risk is downstream breakage if this package is incompatible with Laravel 13 APIs.
> 
> **Overview**
> Adds Laravel 13 compatibility by expanding Composer version constraints for `illuminate/contracts`, `illuminate/support`, and `laravel/framework` to include `^13.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5524274ec96b32cbdd5268c8656d4f5c8c15a19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->