### PR TITLE
Prove PHP 7 was already broken before GHA migration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: ['7.2', '7.3']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Install dependencies
+        run: composer install --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/phpunit
+
+      - name: Run Psalm
+        run: vendor/bin/psalm --shepherd


### PR DESCRIPTION
## Summary

This is a straight port of the Travis CI config to GitHub Actions with no other changes — same PHP versions (7.2, 7.3), same commands.

The purpose is to demonstrate that PHP 7 support was already broken on master prior to #111, due to the `graham-campbell/manager ^5.0` dependency bump in #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)