### PR TITLE
Allow vimeo/vimeo-api ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/contracts": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "graham-campbell/manager": "^5.0",
-        "vimeo/vimeo-api": "^3.0"
+        "vimeo/vimeo-api": "^3.0|^4.0"
     },
     "require-dev": {
         "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",


### PR DESCRIPTION
v4.0.0 swaps the internal Tus client (ankitpokhrel/tus-php) for a lightweight in-tree implementation. The Vimeo class's public surface — constructor signature, request(), upload() — is unchanged, so the wrapper needs no source changes. Existing tests and psalm pass against 4.0.1.

Closes #114

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the only change is a relaxed dependency constraint, though consumers may see behavior differences when resolving to `vimeo/vimeo-api` v4.
> 
> **Overview**
> Allows this package to be installed with `vimeo/vimeo-api` `^4.0` by widening the version constraint in `composer.json` (from `^3.0` to `^3.0|^4.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00748364ca8a7186b8616f4b4147ca43a362413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->